### PR TITLE
Add additional Arturo dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ install:
  - sudo pip install --upgrade pip
  - sudo pip install jinja2
  - sudo pip install pyserial
+ - sudo pip install configobj
+ - sudo pip install ordereddict
+ - sudo pip install argparse
+ - sudo pip install glob2
  - pwd
 
 script:


### PR DESCRIPTION
Just noticed there is a larger [dependencies list in Arturo](https://github.com/scottdarch/Arturo/blob/master/requirements.txt)
- jinja2
- pyserial
- configobj
- ordereddict
- argparse
- glob2
